### PR TITLE
Make types public

### DIFF
--- a/src/lib.v
+++ b/src/lib.v
@@ -14,9 +14,9 @@ pub enum WatchFlag {
 	follow_symlinks = C.DMON_WATCHFLAGS_FOLLOW_SYMLINKS
 }
 
-type WatchFlags = WatchFlag | u32
+pub type WatchFlags = WatchFlag | u32
 
-type WatchID = u32
+pub type WatchID = u32
 
 fn init() {
 	C.dmon_init()


### PR DESCRIPTION
Solve compilation error when building the README example :

```
main.v:10:22: error: alias `ttytm.vvatch.WatchID` was declared as private to module `ttytm.vv
atch`, so it can not be used inside module `main`
    8 | }
    9 | 
   10 | fn watch_cb(watch_id w.WatchID, action w.Action, root_path string, file_path string, 
old_file_path string, mut app App) {
      |                      ~~~~~~~~~
   11 |     match action {
   12 |         .create { println('created `${file_path}`') }
```
